### PR TITLE
compile packge when installed from github

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "generate-merkle-root": "ts-node scripts/generate-merkle-root.ts",
     "generate-merkle-root:example": "ts-node scripts/generate-merkle-root.ts --input scripts/example.json",
     "prepublishOnly": "yarn test",
-    "prepack": "yarn build"
+    "install": "yarn install --production=false --ignore-scripts && yarn build"
   },
   "packageManager": "yarn@1.22.10",
   "dependencies": {


### PR DESCRIPTION
compile package when installed from github

the real problem was
- the devdependencies did not get installed (yarn installs only prod dependencies)
- the package was not built on install
- yarn ran into an infite loop if install script was specified > --ignore-scripts
- prepare script should have been the correct solution but it was skipped when install script was specified

just for the record:
- yarn cache clean -> yarn cache clean --mirror -> npm uninstall -global yarn -> npm install -global yarn -> yarn
- "packagename": "https://githuburl#master" -> yarn cache will lock in the version first seen